### PR TITLE
feat: 계약서 분석 결과 저장 및 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // amazon s3
+    implementation 'software.amazon.awssdk:s3:2.32.24'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/team4/hanzip/domain/contract/controller/ContractController.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/controller/ContractController.java
@@ -1,0 +1,70 @@
+package org.team4.hanzip.domain.contract.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.team4.hanzip.domain.contract.dto.request.ContractWriteDto;
+import org.team4.hanzip.domain.contract.dto.response.ContractDetailDto;
+import org.team4.hanzip.domain.contract.dto.response.ContractIdDto;
+import org.team4.hanzip.domain.contract.dto.response.ContractListDto;
+import org.team4.hanzip.domain.contract.service.ContractService;
+import org.team4.hanzip.global.api.ApiResponse;
+import org.team4.hanzip.global.api.code.contract.SuccessCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(path = "/api/contracts")
+public class ContractController {
+	private final ContractService contractService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<ContractIdDto>> createContract(
+			@AuthenticationPrincipal final long memberId,
+			@RequestBody final ContractWriteDto contractWriteDto
+	) {
+		return ResponseEntity.status(SuccessCode.CREATED.getStatus())
+				.body(ApiResponse.success(SuccessCode.CREATED,
+						contractService.createContract(memberId, contractWriteDto)));
+	}
+
+	@GetMapping(path = "/{page}")
+	public ResponseEntity<ApiResponse<ContractListDto>> getContractsList(
+			@AuthenticationPrincipal final long memberId,
+			@PathVariable(name = "page") final int page
+	) {
+		return ResponseEntity.status(SuccessCode.OK.getStatus())
+				.body(ApiResponse.success(SuccessCode.OK, contractService.getContractsList(memberId, page)));
+	}
+
+	@GetMapping(path = "/detail/{contractId}")
+	public ResponseEntity<ApiResponse<ContractDetailDto>> getContractDetail(
+			@AuthenticationPrincipal final long memberId,
+			@PathVariable(name = "contractId") final String contractId
+	) {
+		return ResponseEntity.status(SuccessCode.OK.getStatus())
+				.body(ApiResponse.success(SuccessCode.OK, contractService.getContractDetail(memberId, contractId)));
+	}
+
+	@PostMapping(path = "/image/{contractId}")
+	public ResponseEntity<ApiResponse<Void>> uploadImages(
+			@AuthenticationPrincipal final long memberId,
+			@PathVariable(name = "contractId") final String contractId,
+			@RequestPart(name = "image") final List<MultipartFile> images
+	) {
+		contractService.uploadContractImages(memberId, contractId, images);
+
+		return ResponseEntity.status(SuccessCode.CREATED.getStatus())
+				.body(ApiResponse.success(SuccessCode.CREATED));
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/document/Contract.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/document/Contract.java
@@ -1,0 +1,48 @@
+package org.team4.hanzip.domain.contract.document;
+
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.team4.hanzip.global.config.BaseDocument;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "contract")
+public class Contract extends BaseDocument {
+	@Id
+	private String id;
+
+	@Indexed
+	private Long memberId;
+
+	private String contractTitle;
+
+	private List<String> images;
+
+	private Highlight highlight;
+
+	private List<Summary> commonSummary;
+
+	private List<Summary> warningSummary;
+
+	@Builder
+	private Contract(Long memberId, String contractTitle, Highlight highlight, List<Summary> commonSummary,
+			List<Summary> warningSummary) {
+		this.memberId = memberId;
+		this.contractTitle = contractTitle;
+		this.highlight = highlight;
+		this.commonSummary = commonSummary;
+		this.warningSummary = warningSummary;
+	}
+
+	public void updateImages(List<String> images) {
+		this.images = images;
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/document/Highlight.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/document/Highlight.java
@@ -1,0 +1,23 @@
+package org.team4.hanzip.domain.contract.document;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Highlight {
+	private List<String> page1;
+	private List<String> page2;
+	private List<String> page3;
+
+	@Builder
+	public Highlight(List<String> page1, List<String> page2, List<String> page3) {
+		this.page1 = page1;
+		this.page2 = page2;
+		this.page3 = page3;
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/document/Summary.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/document/Summary.java
@@ -1,0 +1,23 @@
+package org.team4.hanzip.domain.contract.document;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Summary {
+	private String title;
+	private String subTitle;
+	List<String> content;
+
+	@Builder
+	private Summary(String title, String subTitle, List<String> content) {
+		this.title = title;
+		this.subTitle = subTitle;
+		this.content = content;
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/common/HighlightDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/common/HighlightDto.java
@@ -1,0 +1,27 @@
+package org.team4.hanzip.domain.contract.dto.common;
+
+import java.util.List;
+
+import org.team4.hanzip.domain.contract.document.Highlight;
+
+public record HighlightDto(
+		List<String> page1,
+		List<String> page2,
+		List<String> page3
+) {
+	public Highlight toDocumentElement() {
+		return Highlight.builder()
+				.page1(page1)
+				.page2(page2)
+				.page3(page3)
+				.build();
+	}
+
+	public static HighlightDto from(final Highlight highlight) {
+		return new HighlightDto(
+				highlight.getPage1(),
+				highlight.getPage2(),
+				highlight.getPage3()
+		);
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/common/SummaryDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/common/SummaryDto.java
@@ -1,0 +1,27 @@
+package org.team4.hanzip.domain.contract.dto.common;
+
+import java.util.List;
+
+import org.team4.hanzip.domain.contract.document.Summary;
+
+public record SummaryDto(
+		String title,
+		String subTitle,
+		List<String> content
+) {
+	public Summary toDocumentElement() {
+		return Summary.builder()
+				.title(title)
+				.subTitle(subTitle)
+				.content(content)
+				.build();
+	}
+
+	public static SummaryDto from(final Summary summary) {
+		return new SummaryDto(
+				summary.getTitle(),
+				summary.getSubTitle(),
+				summary.getContent()
+		);
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/request/ContractWriteDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/request/ContractWriteDto.java
@@ -1,0 +1,24 @@
+package org.team4.hanzip.domain.contract.dto.request;
+
+import java.util.List;
+
+import org.team4.hanzip.domain.contract.document.Contract;
+import org.team4.hanzip.domain.contract.dto.common.HighlightDto;
+import org.team4.hanzip.domain.contract.dto.common.SummaryDto;
+
+public record ContractWriteDto(
+		String contractTitle,
+		HighlightDto highlight,
+		List<SummaryDto> commonSummary,
+		List<SummaryDto> warningSummary
+) {
+	public Contract toDocument(final long memberId){
+		return Contract.builder()
+				.memberId(memberId)
+				.contractTitle(contractTitle)
+				.highlight(highlight.toDocumentElement())
+				.commonSummary(commonSummary.stream().map(SummaryDto::toDocumentElement).toList())
+				.warningSummary(warningSummary.stream().map(SummaryDto::toDocumentElement).toList())
+				.build();
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractDetailDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractDetailDto.java
@@ -1,0 +1,22 @@
+package org.team4.hanzip.domain.contract.dto.response;
+
+import java.util.List;
+
+import org.team4.hanzip.domain.contract.document.Contract;
+import org.team4.hanzip.domain.contract.dto.common.HighlightDto;
+import org.team4.hanzip.domain.contract.dto.common.SummaryDto;
+
+public record ContractDetailDto(
+		List<String> images,
+		HighlightDto highlight,
+		List<SummaryDto> commonSummary,
+		List<SummaryDto> warningSummary) {
+	public static ContractDetailDto from(final Contract contract) {
+		return new ContractDetailDto(
+				contract.getImages(),
+				HighlightDto.from(contract.getHighlight()),
+				contract.getCommonSummary().stream().map(SummaryDto::from).toList(),
+				contract.getWarningSummary().stream().map(SummaryDto::from).toList()
+		);
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractIdDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractIdDto.java
@@ -1,0 +1,7 @@
+package org.team4.hanzip.domain.contract.dto.response;
+
+public record ContractIdDto(String contractId) {
+	public static ContractIdDto of(String contractId) {
+		return new ContractIdDto(contractId);
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractListDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractListDto.java
@@ -22,7 +22,6 @@ public record ContractListDto(
 			LocalDateTime createdDate
 	) {
 		private static ContractListElement from(final Contract contract) {
-			System.out.println(contract.getContractTitle());
 			return new ContractListElement(
 					contract.getId(),
 					contract.getContractTitle(),

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractListDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractListDto.java
@@ -1,0 +1,33 @@
+package org.team4.hanzip.domain.contract.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.team4.hanzip.domain.contract.document.Contract;
+
+public record ContractListDto(
+		List<ContractListElement> contracts,
+		boolean hasNext
+) {
+	public static ContractListDto from(final Slice<Contract> slice) {
+		return new ContractListDto(
+				slice.getContent().stream().map(ContractListElement::from).toList(),
+				slice.hasNext());
+	}
+
+	private record ContractListElement(
+			String contractId,
+			String contractTitle,
+			LocalDateTime createdDate
+	) {
+		private static ContractListElement from(final Contract contract) {
+			System.out.println(contract.getContractTitle());
+			return new ContractListElement(
+					contract.getId(),
+					contract.getContractTitle(),
+					contract.getCreatedDate()
+			);
+		}
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/repository/ContractRepository.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/repository/ContractRepository.java
@@ -1,0 +1,14 @@
+package org.team4.hanzip.domain.contract.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.team4.hanzip.domain.contract.document.Contract;
+
+public interface ContractRepository extends MongoRepository<Contract, String> {
+	Slice<Contract> findByMemberIdOrderByCreatedDateDesc(Long memberId, Pageable pageable);
+
+	Optional<Contract> findByMemberIdAndId(Long memberId, String contractId);
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/service/ContractService.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/service/ContractService.java
@@ -51,9 +51,9 @@ public class ContractService {
 	}
 
 	public void uploadContractImages(final long memberId, final String contractId, final List<MultipartFile> images) {
-		List<String> urls = imageUploader.upload(memberId, contractId, images);
-
 		Contract contract = contractRepository.findByMemberIdAndId(memberId, contractId).orElseThrow(ContractNotFoundException::new);
+
+		List<String> urls = imageUploader.upload(memberId, contractId, images);
 
 		contract.updateImages(urls);
 

--- a/src/main/java/org/team4/hanzip/domain/contract/service/ContractService.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/service/ContractService.java
@@ -1,0 +1,62 @@
+package org.team4.hanzip.domain.contract.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.team4.hanzip.domain.contract.document.Contract;
+import org.team4.hanzip.domain.contract.dto.request.ContractWriteDto;
+import org.team4.hanzip.domain.contract.dto.response.ContractDetailDto;
+import org.team4.hanzip.domain.contract.dto.response.ContractIdDto;
+import org.team4.hanzip.domain.contract.dto.response.ContractListDto;
+import org.team4.hanzip.domain.contract.repository.ContractRepository;
+import org.team4.hanzip.domain.contract.util.ImageUploader;
+import org.team4.hanzip.domain.member.repository.MemberRepository;
+import org.team4.hanzip.global.exception.contract.ContractNotFoundException;
+import org.team4.hanzip.global.exception.member.MemberNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ContractService {
+	private final MemberRepository memberRepository;
+	private final ContractRepository contractRepository;
+	private final ImageUploader imageUploader;
+
+	public ContractIdDto createContract(final long memberId, final ContractWriteDto contractWriteDto) {
+		if(!memberRepository.existsById(memberId)){
+			throw new MemberNotFoundException();
+		}
+
+		return ContractIdDto.of(contractRepository.save(contractWriteDto.toDocument(memberId)).getId());
+	}
+
+	public ContractListDto getContractsList(final long memberId, final int page) {
+		Pageable pageable = PageRequest.of(page, 10);
+
+		Slice<Contract> slice = contractRepository.findByMemberIdOrderByCreatedDateDesc(memberId, pageable);
+
+		return ContractListDto.from(slice);
+	}
+
+	public ContractDetailDto getContractDetail(final long memberId, final String contractId) {
+		Contract contract = contractRepository.findByMemberIdAndId(memberId, contractId)
+				.orElseThrow(ContractNotFoundException::new);
+
+		return ContractDetailDto.from(contract);
+	}
+
+	public void uploadContractImages(final long memberId, final String contractId, final List<MultipartFile> images) {
+		List<String> urls = imageUploader.upload(memberId, contractId, images);
+
+		Contract contract = contractRepository.findByMemberIdAndId(memberId, contractId).orElseThrow(ContractNotFoundException::new);
+
+		contract.updateImages(urls);
+
+		contractRepository.save(contract);
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/util/ImageUploader.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/util/ImageUploader.java
@@ -1,0 +1,85 @@
+package org.team4.hanzip.domain.contract.util;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.team4.hanzip.global.exception.contract.FileExtensionNotFoundException;
+import org.team4.hanzip.global.exception.contract.FileNotFoundException;
+import org.team4.hanzip.global.exception.contract.InvalidFileExtensionException;
+
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+@RequiredArgsConstructor
+public class ImageUploader {
+	private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png");
+	private final S3Client s3Client;
+
+	@Value("${aws.s3.bucket-name}")
+	private String bucketName;
+
+	// https://tao-tech.tistory.com/27
+
+	public List<String> upload(final long memberId, final String contractId, final List<MultipartFile> images) {
+		validateFiles(images);
+
+		return IntStream.range(0, images.size())
+				.mapToObj(idx -> {
+					String filenameToUpload = memberId + "-" + contractId + "-" + idx;
+					return uploadToS3(filenameToUpload, images.get(idx));
+				})
+				.toList();
+	}
+
+	private void validateFiles(final List<MultipartFile> images) {
+		images.forEach(image -> {
+			String fileName = image.getOriginalFilename();
+
+			// 파일 존재 유무 검증
+			if (fileName == null || fileName.isEmpty()) {
+				throw new FileNotFoundException();
+			}
+
+			// 파일 확장자 존재 유무 검증
+			if (fileName.lastIndexOf(".") == -1) {
+				throw new FileExtensionNotFoundException();
+			}
+
+			if (!ALLOWED_EXTENSIONS.contains(fileName.substring(fileName.lastIndexOf(".") + 1))) {
+				throw new InvalidFileExtensionException();
+			}
+		});
+	}
+
+	private String uploadToS3(final String filenameToUpload, MultipartFile image) {
+
+		String extension = Objects.requireNonNull(image.getOriginalFilename())
+				.substring(image.getOriginalFilename().lastIndexOf(".") + 1);
+
+		try (InputStream inputStream = image.getInputStream()) {
+			PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+					.bucket(bucketName)
+					.key(filenameToUpload)
+					.acl(ObjectCannedACL.PUBLIC_READ)
+					.contentType("image/" + extension)
+					.contentLength(image.getSize())
+					.build();
+			s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, image.getSize()));
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		return s3Client.utilities()
+				.getUrl(url -> url.bucket(bucketName).key(filenameToUpload)).toString();
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/util/ImageUploader.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/util/ImageUploader.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.team4.hanzip.global.exception.contract.FileExtensionNotFoundException;
-import org.team4.hanzip.global.exception.contract.FileNotFoundException;
+import org.team4.hanzip.global.exception.contract.ImageFileNotFoundException;
 import org.team4.hanzip.global.exception.contract.InvalidFileExtensionException;
 
 import lombok.RequiredArgsConstructor;
@@ -47,7 +47,7 @@ public class ImageUploader {
 
 			// 파일 존재 유무 검증
 			if (fileName == null || fileName.isEmpty()) {
-				throw new FileNotFoundException();
+				throw new ImageFileNotFoundException();
 			}
 
 			// 파일 확장자 존재 유무 검증

--- a/src/main/java/org/team4/hanzip/global/api/code/common/ErrorCode.java
+++ b/src/main/java/org/team4/hanzip/global/api/code/common/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode implements ErrorResultCode {
 	INVALID_REQUEST_CONTENT(HttpStatus.BAD_REQUEST, "올바르지 않은 요청 데이터입니다."),
 	MISSING_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 요청값이 존재하지 않습니다."),
 	INVALID_REQUEST_PATH(HttpStatus.NOT_FOUND, "올바르지 않은 요청 경로입니다."),
-	INVALID_HTTP_METHOD(HttpStatus.METHOD_NOT_ALLOWED, "올바르지 않은 HTTP 메서드입니다.");
+	INVALID_HTTP_METHOD(HttpStatus.METHOD_NOT_ALLOWED, "올바르지 않은 HTTP 메서드입니다."),
+	FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "파일 용량이 초과되었습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/team4/hanzip/global/api/code/contract/ErrorCode.java
+++ b/src/main/java/org/team4/hanzip/global/api/code/contract/ErrorCode.java
@@ -9,7 +9,12 @@ import org.team4.hanzip.global.api.code.ErrorResultCode;
 @RequiredArgsConstructor
 public enum ErrorCode implements ErrorResultCode {
 	INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "올바르지 않은 요청값입니다."),
-	CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다.");
+	CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다."),
+
+	// 이미지 업로드 시 예외
+	FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "파일이 존재하지 않습니다."),
+	FILE_EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "파일 확장자가 존재하지 않습니다."),
+	INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "올바르지 않은 파일 확장자입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/team4/hanzip/global/config/BaseDocument.java
+++ b/src/main/java/org/team4/hanzip/global/config/BaseDocument.java
@@ -1,0 +1,17 @@
+package org.team4.hanzip.global.config;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public abstract class BaseDocument {
+	@CreatedDate
+	@Field(name = "created_date")
+	private LocalDateTime createdDate;
+
+	public LocalDateTime getCreatedDate() {
+		return createdDate.atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+	}
+}

--- a/src/main/java/org/team4/hanzip/global/config/MongoAuditingConfig.java
+++ b/src/main/java/org/team4/hanzip/global/config/MongoAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.team4.hanzip.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoAuditingConfig {
+}

--- a/src/main/java/org/team4/hanzip/global/config/S3Config.java
+++ b/src/main/java/org/team4/hanzip/global/config/S3Config.java
@@ -1,0 +1,31 @@
+package org.team4.hanzip.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+	@Value("${aws.access-key}")
+	private String accessKey;
+
+	@Value("${aws.secret-key}")
+	private String secretKey;
+
+	@Value("${aws.region}")
+	private String region;
+
+	@Bean
+	public S3Client s3Client(){
+		AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+		return S3Client.builder()
+				.credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+				.region(Region.of(region))
+				.build();
+	}
+}

--- a/src/main/java/org/team4/hanzip/global/exception/contract/FileExtensionNotFoundException.java
+++ b/src/main/java/org/team4/hanzip/global/exception/contract/FileExtensionNotFoundException.java
@@ -1,0 +1,10 @@
+package org.team4.hanzip.global.exception.contract;
+
+import org.team4.hanzip.global.api.code.contract.ErrorCode;
+import org.team4.hanzip.global.exception.common.CommonException;
+
+public class FileExtensionNotFoundException extends CommonException {
+	public FileExtensionNotFoundException() {
+		super(ErrorCode.FILE_EXTENSION_NOT_FOUND);
+	}
+}

--- a/src/main/java/org/team4/hanzip/global/exception/contract/FileNotFoundException.java
+++ b/src/main/java/org/team4/hanzip/global/exception/contract/FileNotFoundException.java
@@ -1,0 +1,11 @@
+package org.team4.hanzip.global.exception.contract;
+
+import org.team4.hanzip.global.api.code.ErrorResultCode;
+import org.team4.hanzip.global.api.code.contract.ErrorCode;
+import org.team4.hanzip.global.exception.common.CommonException;
+
+public class FileNotFoundException extends CommonException {
+	public FileNotFoundException() {
+		super(ErrorCode.FILE_NOT_FOUND);
+	}
+}

--- a/src/main/java/org/team4/hanzip/global/exception/contract/ImageFileNotFoundException.java
+++ b/src/main/java/org/team4/hanzip/global/exception/contract/ImageFileNotFoundException.java
@@ -1,11 +1,10 @@
 package org.team4.hanzip.global.exception.contract;
 
-import org.team4.hanzip.global.api.code.ErrorResultCode;
 import org.team4.hanzip.global.api.code.contract.ErrorCode;
 import org.team4.hanzip.global.exception.common.CommonException;
 
-public class FileNotFoundException extends CommonException {
-	public FileNotFoundException() {
+public class ImageFileNotFoundException extends CommonException {
+	public ImageFileNotFoundException() {
 		super(ErrorCode.FILE_NOT_FOUND);
 	}
 }

--- a/src/main/java/org/team4/hanzip/global/exception/contract/InvalidFileExtensionException.java
+++ b/src/main/java/org/team4/hanzip/global/exception/contract/InvalidFileExtensionException.java
@@ -1,0 +1,10 @@
+package org.team4.hanzip.global.exception.contract;
+
+import org.team4.hanzip.global.api.code.contract.ErrorCode;
+import org.team4.hanzip.global.exception.common.CommonException;
+
+public class InvalidFileExtensionException extends CommonException {
+	public InvalidFileExtensionException() {
+		super(ErrorCode.INVALID_FILE_EXTENSION);
+	}
+}

--- a/src/main/java/org/team4/hanzip/global/exception/handler/CommonExceptionHandler.java
+++ b/src/main/java/org/team4/hanzip/global/exception/handler/CommonExceptionHandler.java
@@ -6,6 +6,8 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.team4.hanzip.global.api.ApiResponse;
 import org.team4.hanzip.global.api.code.common.ErrorCode;
@@ -29,9 +31,21 @@ public class CommonExceptionHandler extends BaseExceptionHandler {
 		return buildErrorResponse(ErrorCode.INVALID_REQUEST_CONTENT);
 	}
 
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchExceptionException(
+			MethodArgumentTypeMismatchException e) {
+		return buildErrorResponse(ErrorCode.MISSING_REQUIRED_PARAMETER);
+	}
+
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	protected ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(
 			MissingServletRequestParameterException e) {
 		return buildErrorResponse(ErrorCode.MISSING_REQUIRED_PARAMETER);
+	}
+
+	@ExceptionHandler(MaxUploadSizeExceededException.class)
+	protected ResponseEntity<ApiResponse<Void>> handleMaxUploadSizeExceededException(
+			MaxUploadSizeExceededException e) {
+		return buildErrorResponse(ErrorCode.FILE_SIZE_EXCEEDED);
 	}
 }

--- a/src/main/java/org/team4/hanzip/global/exception/handler/ContractExceptionHandler.java
+++ b/src/main/java/org/team4/hanzip/global/exception/handler/ContractExceptionHandler.java
@@ -1,13 +1,12 @@
 package org.team4.hanzip.global.exception.handler;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.team4.hanzip.global.api.ApiResponse;
 import org.team4.hanzip.global.exception.contract.ContractNotFoundException;
 import org.team4.hanzip.global.exception.contract.FileExtensionNotFoundException;
-import org.team4.hanzip.global.exception.contract.FileNotFoundException;
+import org.team4.hanzip.global.exception.contract.ImageFileNotFoundException;
 import org.team4.hanzip.global.exception.contract.InvalidFileExtensionException;
 
 @RestControllerAdvice
@@ -17,8 +16,8 @@ public class ContractExceptionHandler extends BaseExceptionHandler {
 		return buildErrorResponse(e.getErrorResultCode());
 	}
 
-	@ExceptionHandler(FileNotFoundException.class)
-	protected ResponseEntity<ApiResponse<Void>> handleFileNotFoundException(FileNotFoundException e) {
+	@ExceptionHandler(ImageFileNotFoundException.class)
+	protected ResponseEntity<ApiResponse<Void>> handleFileNotFoundException(ImageFileNotFoundException e) {
 		return buildErrorResponse(e.getErrorResultCode());
 	}
 

--- a/src/main/java/org/team4/hanzip/global/exception/handler/ContractExceptionHandler.java
+++ b/src/main/java/org/team4/hanzip/global/exception/handler/ContractExceptionHandler.java
@@ -1,15 +1,34 @@
 package org.team4.hanzip.global.exception.handler;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.team4.hanzip.global.api.ApiResponse;
 import org.team4.hanzip.global.exception.contract.ContractNotFoundException;
+import org.team4.hanzip.global.exception.contract.FileExtensionNotFoundException;
+import org.team4.hanzip.global.exception.contract.FileNotFoundException;
+import org.team4.hanzip.global.exception.contract.InvalidFileExtensionException;
 
 @RestControllerAdvice
 public class ContractExceptionHandler extends BaseExceptionHandler {
 	@ExceptionHandler(ContractNotFoundException.class)
 	protected ResponseEntity<ApiResponse<Void>> handleContractNotFoundException(ContractNotFoundException e) {
+		return buildErrorResponse(e.getErrorResultCode());
+	}
+
+	@ExceptionHandler(FileNotFoundException.class)
+	protected ResponseEntity<ApiResponse<Void>> handleFileNotFoundException(FileNotFoundException e) {
+		return buildErrorResponse(e.getErrorResultCode());
+	}
+
+	@ExceptionHandler(FileExtensionNotFoundException.class)
+	protected ResponseEntity<ApiResponse<Void>> handleFileExtensionNotFoundException(FileExtensionNotFoundException e) {
+		return buildErrorResponse(e.getErrorResultCode());
+	}
+
+	@ExceptionHandler(InvalidFileExtensionException.class)
+	protected ResponseEntity<ApiResponse<Void>> handleInvalidFileExtensionException(InvalidFileExtensionException e) {
 		return buildErrorResponse(e.getErrorResultCode());
 	}
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 계약서 분석 결과에 대한 저장 및 조회 기능을 구현합니다.
- 계약서 원본 이미지 업로드 기능을 구현합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 계약서 분석 결과 저장 기능 구현
- [x] 계약서 분석 결과 조회 기능 구현
- [x] 계약서 분석 결과 상세 정보 조회 기능 구현
- [x] 계약서 원본 이미지 업로드 기능 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 계약서 분석 결과 저장
  <img width="797" height="568" alt="스크린샷 2025-08-22 오전 12 14 34" src="https://github.com/user-attachments/assets/ddf2ed5b-e8c6-46ba-a892-bd13be6cacce" />

- 계약서 분석 결과 목록 조회
  <img width="790" height="684" alt="스크린샷 2025-08-22 오전 12 14 52" src="https://github.com/user-attachments/assets/ed78c346-a47d-4190-bd13-f7200a5c6ca5" />

- 계약서 분석 결과 상세 정보 조회
  <img width="802" height="679" alt="스크린샷 2025-08-22 오전 12 15 22" src="https://github.com/user-attachments/assets/5ac4b448-8818-4fa5-8771-84eaa596ed29" />

- 계약서 원본 이미지 업로드
  <img width="793" height="521" alt="스크린샷 2025-08-22 오전 12 15 40" src="https://github.com/user-attachments/assets/6cd7264d-3f81-4635-8549-0ae57afc9a83" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 이미지 업로드랑 계약서 분석 결과 정보 저장 로직이 요구사항의 특성상 결합도가 높은 편입니다.
- 현재 계약서 분석 결과 저장 후 바로 이미지 업로드를 통해 기능이 정상 동작하도록 되어있는데, 결합도가 낮은 다른 좋은 방법에 대해 알려주시면 감사드립니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 계약 생성, 페이지네이션 목록 조회, 상세 조회 API를 제공합니다.
  - 계약 이미지 업로드를 지원하고(JPG/PNG 검증), 업로드된 이미지 URL이 계약에 반영됩니다.
  - 파일 크기 초과, 잘못된/누락된 확장자, 잘못된 파라미터 타입 등에 대해 명확한 에러 코드와 응답을 제공합니다.
- 작업
  - S3 연동 구성 및 업로드 용량 제한 처리 설정을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->