### PR TITLE
feat: OCR 하이라이팅 좌표값 추가

### DIFF
--- a/src/main/java/org/team4/hanzip/domain/contract/document/Contract.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/document/Contract.java
@@ -22,7 +22,7 @@ public class Contract extends BaseDocument {
 	@Indexed
 	private Long memberId;
 
-	private String contractTitle;
+	private String contractName;
 
 	private List<String> images;
 
@@ -33,10 +33,10 @@ public class Contract extends BaseDocument {
 	private List<Summary> warningSummary;
 
 	@Builder
-	private Contract(Long memberId, String contractTitle, Highlight highlight, List<Summary> commonSummary,
+	private Contract(Long memberId, String contractName, Highlight highlight, List<Summary> commonSummary,
 			List<Summary> warningSummary) {
 		this.memberId = memberId;
-		this.contractTitle = contractTitle;
+		this.contractName = contractName;
 		this.highlight = highlight;
 		this.commonSummary = commonSummary;
 		this.warningSummary = warningSummary;

--- a/src/main/java/org/team4/hanzip/domain/contract/document/Highlight.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/document/Highlight.java
@@ -10,12 +10,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Highlight {
-	private List<String> page1;
-	private List<String> page2;
-	private List<String> page3;
+	private List<SentenceInfo> page1;
+	private List<SentenceInfo> page2;
+	private List<SentenceInfo> page3;
 
 	@Builder
-	public Highlight(List<String> page1, List<String> page2, List<String> page3) {
+	public Highlight(List<SentenceInfo> page1, List<SentenceInfo> page2, List<SentenceInfo> page3) {
 		this.page1 = page1;
 		this.page2 = page2;
 		this.page3 = page3;

--- a/src/main/java/org/team4/hanzip/domain/contract/document/SentenceInfo.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/document/SentenceInfo.java
@@ -1,0 +1,21 @@
+package org.team4.hanzip.domain.contract.document;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SentenceInfo {
+	private String content;
+	private List<Vertex> vertices;
+
+	@Builder
+	private SentenceInfo(String content, List<Vertex> vertices) {
+		this.content = content;
+		this.vertices = vertices;
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/document/Vertex.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/document/Vertex.java
@@ -1,0 +1,19 @@
+package org.team4.hanzip.domain.contract.document;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vertex {
+	private int x;
+	private int y;
+
+	@Builder
+	private Vertex(int x, int y) {
+		this.x = x;
+		this.y = y;
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/common/HighlightDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/common/HighlightDto.java
@@ -5,23 +5,23 @@ import java.util.List;
 import org.team4.hanzip.domain.contract.document.Highlight;
 
 public record HighlightDto(
-		List<String> page1,
-		List<String> page2,
-		List<String> page3
+		List<SentenceInfoDto> page1,
+		List<SentenceInfoDto> page2,
+		List<SentenceInfoDto> page3
 ) {
 	public Highlight toDocumentElement() {
 		return Highlight.builder()
-				.page1(page1)
-				.page2(page2)
-				.page3(page3)
+				.page1(page1.stream().map(SentenceInfoDto::toSentenceInfo).toList())
+				.page2(page2.stream().map(SentenceInfoDto::toSentenceInfo).toList())
+				.page3(page3.stream().map(SentenceInfoDto::toSentenceInfo).toList())
 				.build();
 	}
 
 	public static HighlightDto from(final Highlight highlight) {
 		return new HighlightDto(
-				highlight.getPage1(),
-				highlight.getPage2(),
-				highlight.getPage3()
+				highlight.getPage1().stream().map(SentenceInfoDto::from).toList(),
+				highlight.getPage2().stream().map(SentenceInfoDto::from).toList(),
+				highlight.getPage3().stream().map(SentenceInfoDto::from).toList()
 		);
 	}
 }

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/common/SentenceInfoDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/common/SentenceInfoDto.java
@@ -1,0 +1,42 @@
+package org.team4.hanzip.domain.contract.dto.common;
+
+import java.util.List;
+
+import org.team4.hanzip.domain.contract.document.SentenceInfo;
+import org.team4.hanzip.domain.contract.document.Vertex;
+
+public record SentenceInfoDto(
+		String content,
+		List<VertexDto> vertices
+) {
+	public SentenceInfo toSentenceInfo() {
+		return SentenceInfo.builder()
+				.content(content)
+				.vertices(vertices.stream().map(VertexDto::toVertex).toList())
+				.build();
+	}
+
+	public static SentenceInfoDto from(SentenceInfo sentenceInfo) {
+		return new SentenceInfoDto(
+				sentenceInfo.getContent(),
+				sentenceInfo.getVertices().stream().map(VertexDto::from).toList()
+		);
+	}
+
+	private record VertexDto(int x, int y) {
+		private Vertex toVertex() {
+			return Vertex.builder()
+					.x(x)
+					.y(y)
+					.build();
+		}
+
+		private static VertexDto from(Vertex vertex) {
+			return new VertexDto(vertex.getX(), vertex.getY());
+		}
+
+		private static VertexDto of(int x, int y) {
+			return new VertexDto(x, y);
+		}
+	}
+}

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/common/SentenceInfoDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/common/SentenceInfoDto.java
@@ -9,6 +9,11 @@ public record SentenceInfoDto(
 		String content,
 		List<VertexDto> vertices
 ) {
+	public SentenceInfoDto(String content, List<VertexDto> vertices) {
+		this.content = content;
+		this.vertices = vertices == null ? List.of() : vertices;
+	}
+
 	public SentenceInfo toSentenceInfo() {
 		return SentenceInfo.builder()
 				.content(content)
@@ -23,7 +28,7 @@ public record SentenceInfoDto(
 		);
 	}
 
-	private record VertexDto(int x, int y) {
+	public record VertexDto(int x, int y) {
 		private Vertex toVertex() {
 			return Vertex.builder()
 					.x(x)
@@ -33,10 +38,6 @@ public record SentenceInfoDto(
 
 		private static VertexDto from(Vertex vertex) {
 			return new VertexDto(vertex.getX(), vertex.getY());
-		}
-
-		private static VertexDto of(int x, int y) {
-			return new VertexDto(x, y);
 		}
 	}
 }

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/request/ContractWriteDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/request/ContractWriteDto.java
@@ -7,15 +7,15 @@ import org.team4.hanzip.domain.contract.dto.common.HighlightDto;
 import org.team4.hanzip.domain.contract.dto.common.SummaryDto;
 
 public record ContractWriteDto(
-		String contractTitle,
+		String contractName,
 		HighlightDto highlight,
 		List<SummaryDto> commonSummary,
 		List<SummaryDto> warningSummary
 ) {
-	public Contract toDocument(final long memberId){
+	public Contract toDocument(final long memberId) {
 		return Contract.builder()
 				.memberId(memberId)
-				.contractTitle(contractTitle)
+				.contractName(contractName)
 				.highlight(highlight.toDocumentElement())
 				.commonSummary(commonSummary.stream().map(SummaryDto::toDocumentElement).toList())
 				.warningSummary(warningSummary.stream().map(SummaryDto::toDocumentElement).toList())

--- a/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractListDto.java
+++ b/src/main/java/org/team4/hanzip/domain/contract/dto/response/ContractListDto.java
@@ -18,13 +18,13 @@ public record ContractListDto(
 
 	private record ContractListElement(
 			String contractId,
-			String contractTitle,
+			String contractName,
 			LocalDateTime createdDate
 	) {
 		private static ContractListElement from(final Contract contract) {
 			return new ContractListElement(
 					contract.getId(),
-					contract.getContractTitle(),
+					contract.getContractName(),
 					contract.getCreatedDate()
 			);
 		}


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 계약서 분석 결과 저장 과정에서 OCR결과를 하이라이팅하기 위한 좌표값을 추가합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 하이라이팅 구역에 대한 좌표를 저장하는 `vertex`구현
- [x] 계약서 분석 내용 저장 및 조회 과정에서의 `vertex`데이터 추가

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- `vertex`추가 후 요청 과정
  <img width="803" height="472" alt="스크린샷 2025-08-24 오후 2 20 52" src="https://github.com/user-attachments/assets/309f643b-4c62-4313-b106-9f88093a1bd3" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 계약서 분석 데이터 저장에서의 요청 바디와 계약서 분석 내용 상세 조회의 응답 바디, 저장을 위한 도큐먼트에서의 변경이 발생하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 하이라이트가 문장 단위 정보(문장 내용 및 좌표)를 포함하도록 개선되어 페이지별 표시 정확도와 가독성이 향상됩니다.
- Refactor
  - UI·API 표기 통일: ‘계약 제목(contractTitle)’이 ‘계약명(contractName)’으로 변경되어 모든 화면과 응답에서 일관되게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->